### PR TITLE
Index.html - HTTP URL for prefixy.io

### DIFF
--- a/_site/index.html
+++ b/_site/index.html
@@ -163,7 +163,7 @@
 
 <p><strong>This is the story of how we built Prefixy: a highly scalable, query optimized, hosted prefix search service for building autocomplete suggestions.</strong></p>
 
-<p>Want to see it in action? Try Prefixy at <a href="https://www.prefixy.io" target="_blank">prefixy.io</a>.</p>
+<p>Want to see it in action? Try Prefixy at <a href="http://www.prefixy.io" target="_blank">prefixy.io</a>.</p>
 
 <p><img style="display:none;" src="/assets/social.png" alt="screenshot" /></p>
 


### PR DESCRIPTION
Looks like the certificate on https://www.prefixy.io is not configured properly:
![image](https://user-images.githubusercontent.com/416477/62752156-2ccc9880-ba1b-11e9-96ae-cb976887ed58.png)

Proposing using plain HTTP here instead.
